### PR TITLE
fix: migrate deprecated Property.of() to Property.ofValue()

### DIFF
--- a/src/main/java/io/kestra/plugin/shopify/AbstractShopifyTask.java
+++ b/src/main/java/io/kestra/plugin/shopify/AbstractShopifyTask.java
@@ -46,14 +46,14 @@ public abstract class AbstractShopifyTask extends Task {
         description = "Shopify Admin API version path segment; defaults to 2024-10"
     )
     @Builder.Default
-    protected Property<String> apiVersion = Property.of("2024-10");
+    protected Property<String> apiVersion = Property.ofValue("2024-10");
 
     @Schema(
         title = "Rate limit delay",
         description = "Sleep between API calls to respect Shopify rate limits; default 500ms"
     )
     @Builder.Default
-    protected Property<Duration> rateLimitDelay = Property.of(Duration.ofMillis(500));
+    protected Property<Duration> rateLimitDelay = Property.ofValue(Duration.ofMillis(500));
 
     protected URI buildApiUrl(RunContext runContext, String path) throws Exception {
         String rStoreDomain = runContext.render(storeDomain).as(String.class).orElseThrow(() -> 

--- a/src/main/java/io/kestra/plugin/shopify/customers/List.java
+++ b/src/main/java/io/kestra/plugin/shopify/customers/List.java
@@ -73,7 +73,7 @@ public class List extends AbstractShopifyTask implements RunnableTask<List.Outpu
     )
     @Builder.Default
     @NotNull
-    protected Property<FetchType> fetchType = Property.of(FetchType.FETCH);
+    protected Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
     
     @Schema(
         title = "Customer limit",

--- a/src/main/java/io/kestra/plugin/shopify/orders/List.java
+++ b/src/main/java/io/kestra/plugin/shopify/orders/List.java
@@ -94,7 +94,7 @@ public class List extends AbstractShopifyTask implements RunnableTask<List.Outpu
         description = "Controls result handling: FETCH (default), FETCH_ONE, or STORE"
     )
     @Builder.Default
-    private Property<FetchType> fetchType = Property.of(FetchType.FETCH);
+    private Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Schema(
         title = "Limit",

--- a/src/main/java/io/kestra/plugin/shopify/products/List.java
+++ b/src/main/java/io/kestra/plugin/shopify/products/List.java
@@ -91,7 +91,7 @@ public class List extends AbstractShopifyTask implements RunnableTask<List.Outpu
         description = "Controls result handling: FETCH (default), FETCH_ONE, or STORE"
     )
     @Builder.Default
-    private Property<FetchType> fetchType = Property.of(FetchType.FETCH);
+    private Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Schema(
         title = "Limit",

--- a/src/test/java/io/kestra/plugin/shopify/AbstractShopifyTaskTest.java
+++ b/src/test/java/io/kestra/plugin/shopify/AbstractShopifyTaskTest.java
@@ -27,9 +27,9 @@ class AbstractShopifyTaskTest {
         Get task = Get.builder()
             .id("test-task")
             .type(Get.class.getName())
-            .storeDomain(Property.of("test-store.myshopify.com"))
-            .accessToken(Property.of("test-token"))
-            .customerId(Property.of(123L))
+            .storeDomain(Property.ofValue("test-store.myshopify.com"))
+            .accessToken(Property.ofValue("test-token"))
+            .customerId(Property.ofValue(123L))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -47,9 +47,9 @@ class AbstractShopifyTaskTest {
     @Test
     void testPropertyRendering() throws Exception {
         Get task = Get.builder()
-            .storeDomain(Property.of("test-store.myshopify.com"))
-            .accessToken(Property.of("test-token"))
-            .customerId(Property.of(123L))
+            .storeDomain(Property.ofValue("test-store.myshopify.com"))
+            .accessToken(Property.ofValue("test-token"))
+            .customerId(Property.ofValue(123L))
             .build();
 
         // Test property getters execute

--- a/src/test/java/io/kestra/plugin/shopify/customers/CreateTest.java
+++ b/src/test/java/io/kestra/plugin/shopify/customers/CreateTest.java
@@ -26,8 +26,8 @@ class CreateTest {
             Create task = Create.builder()
                 .id("test-task")
                 .type(Create.class.getName())
-                .accessToken(Property.of("test-token"))
-                .email(Property.of("test@example.com"))
+                .accessToken(Property.ofValue("test-token"))
+                .email(Property.ofValue("test@example.com"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -39,8 +39,8 @@ class CreateTest {
             Create task = Create.builder()
                 .id("test-task")
                 .type(Create.class.getName())
-                .storeDomain(Property.of("test-store.myshopify.com"))
-                .email(Property.of("test@example.com"))
+                .storeDomain(Property.ofValue("test-store.myshopify.com"))
+                .email(Property.ofValue("test@example.com"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -52,8 +52,8 @@ class CreateTest {
             Create task = Create.builder()
                 .id("test-task")
                 .type(Create.class.getName())
-                .storeDomain(Property.of("test-store.myshopify.com"))
-                .accessToken(Property.of("test-token"))
+                .storeDomain(Property.ofValue("test-store.myshopify.com"))
+                .accessToken(Property.ofValue("test-token"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -67,11 +67,11 @@ class CreateTest {
         Create task = Create.builder()
             .id("test-task")
             .type(Create.class.getName())
-            .storeDomain(Property.of("test-store.myshopify.com"))
-            .accessToken(Property.of("test-token"))
-            .email(Property.of("test@example.com"))
-            .firstName(Property.of("John"))
-            .lastName(Property.of("Doe"))
+            .storeDomain(Property.ofValue("test-store.myshopify.com"))
+            .accessToken(Property.ofValue("test-token"))
+            .email(Property.ofValue("test@example.com"))
+            .firstName(Property.ofValue("John"))
+            .lastName(Property.ofValue("Doe"))
             .build();
 
         assertThat(task.getStoreDomain(), notNullValue());

--- a/src/test/java/io/kestra/plugin/shopify/customers/GetTest.java
+++ b/src/test/java/io/kestra/plugin/shopify/customers/GetTest.java
@@ -26,8 +26,8 @@ class GetTest {
             Get task = Get.builder()
                 .id("test-task")
                 .type(Get.class.getName())
-                .accessToken(Property.of("test-token"))
-                .customerId(Property.of(123L))
+                .accessToken(Property.ofValue("test-token"))
+                .customerId(Property.ofValue(123L))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -39,8 +39,8 @@ class GetTest {
             Get task = Get.builder()
                 .id("test-task")
                 .type(Get.class.getName())
-                .storeDomain(Property.of("test-store.myshopify.com"))
-                .customerId(Property.of(123L))
+                .storeDomain(Property.ofValue("test-store.myshopify.com"))
+                .customerId(Property.ofValue(123L))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -52,8 +52,8 @@ class GetTest {
             Get task = Get.builder()
                 .id("test-task")
                 .type(Get.class.getName())
-                .storeDomain(Property.of("test-store.myshopify.com"))
-                .accessToken(Property.of("test-token"))
+                .storeDomain(Property.ofValue("test-store.myshopify.com"))
+                .accessToken(Property.ofValue("test-token"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -67,9 +67,9 @@ class GetTest {
         Get task = Get.builder()
             .id("test-task")
             .type(Get.class.getName())
-            .storeDomain(Property.of("test-store.myshopify.com"))
-            .accessToken(Property.of("test-token"))
-            .customerId(Property.of(123L))
+            .storeDomain(Property.ofValue("test-store.myshopify.com"))
+            .accessToken(Property.ofValue("test-token"))
+            .customerId(Property.ofValue(123L))
             .build();
 
         assertThat(task.getStoreDomain(), notNullValue());

--- a/src/test/java/io/kestra/plugin/shopify/customers/ListTest.java
+++ b/src/test/java/io/kestra/plugin/shopify/customers/ListTest.java
@@ -32,9 +32,9 @@ class ListTest {
         List task = List.builder()
             .id("test-task")
             .type(List.class.getName())
-            .storeDomain(Property.of(storeDomain))
-            .accessToken(Property.of(accessToken))
-            .limit(Property.of(5))
+            .storeDomain(Property.ofValue(storeDomain))
+            .accessToken(Property.ofValue(accessToken))
+            .limit(Property.ofValue(5))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -58,7 +58,7 @@ class ListTest {
             List task = List.builder()
                 .id("test-task")
                 .type(List.class.getName())
-                .accessToken(Property.of("test-token"))
+                .accessToken(Property.ofValue("test-token"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -70,7 +70,7 @@ class ListTest {
             List task = List.builder()
                 .id("test-task")
                 .type(List.class.getName())
-                .storeDomain(Property.of("test-store.myshopify.com"))
+                .storeDomain(Property.ofValue("test-store.myshopify.com"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -84,10 +84,10 @@ class ListTest {
         List task = List.builder()
             .id("test-task")
             .type(List.class.getName())
-            .storeDomain(Property.of("test-store.myshopify.com"))
-            .accessToken(Property.of("test-token"))
-            .limit(Property.of(10))
-            .fetchType(Property.of(FetchType.FETCH))
+            .storeDomain(Property.ofValue("test-store.myshopify.com"))
+            .accessToken(Property.ofValue("test-token"))
+            .limit(Property.ofValue(10))
+            .fetchType(Property.ofValue(FetchType.FETCH))
             .build();
 
         assertThat(task.getStoreDomain(), notNullValue());
@@ -100,15 +100,15 @@ class ListTest {
     void testFetchTypeConfiguration() {
         // Test FetchType property configuration
         List task1 = List.builder()
-            .storeDomain(Property.of("test-store.myshopify.com"))
-            .accessToken(Property.of("test-token"))
-            .fetchType(Property.of(FetchType.FETCH))
+            .storeDomain(Property.ofValue("test-store.myshopify.com"))
+            .accessToken(Property.ofValue("test-token"))
+            .fetchType(Property.ofValue(FetchType.FETCH))
             .build();
 
         List task2 = List.builder()
-            .storeDomain(Property.of("test-store.myshopify.com"))
-            .accessToken(Property.of("test-token"))
-            .fetchType(Property.of(FetchType.STORE))
+            .storeDomain(Property.ofValue("test-store.myshopify.com"))
+            .accessToken(Property.ofValue("test-token"))
+            .fetchType(Property.ofValue(FetchType.STORE))
             .build();
 
         assertNotNull(task1.getFetchType());

--- a/src/test/java/io/kestra/plugin/shopify/orders/ListOrdersTest.java
+++ b/src/test/java/io/kestra/plugin/shopify/orders/ListOrdersTest.java
@@ -32,9 +32,9 @@ class ListOrdersTest {
         List task = List.builder()
             .id("test-task")
             .type(List.class.getName())
-            .storeDomain(Property.of(storeDomain))
-            .accessToken(Property.of(accessToken))
-            .limit(Property.of(5))
+            .storeDomain(Property.ofValue(storeDomain))
+            .accessToken(Property.ofValue(accessToken))
+            .limit(Property.ofValue(5))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -58,7 +58,7 @@ class ListOrdersTest {
             List task = List.builder()
                 .id("test-task")
                 .type(List.class.getName())
-                .accessToken(Property.of("test-token"))
+                .accessToken(Property.ofValue("test-token"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -70,7 +70,7 @@ class ListOrdersTest {
             List task = List.builder()
                 .id("test-task")
                 .type(List.class.getName())
-                .storeDomain(Property.of("test-store.myshopify.com"))
+                .storeDomain(Property.ofValue("test-store.myshopify.com"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -84,10 +84,10 @@ class ListOrdersTest {
         List task = List.builder()
             .id("test-task")
             .type(List.class.getName())
-            .storeDomain(Property.of("test-store.myshopify.com"))
-            .accessToken(Property.of("test-token"))
-            .limit(Property.of(10))
-            .fetchType(Property.of(FetchType.FETCH))
+            .storeDomain(Property.ofValue("test-store.myshopify.com"))
+            .accessToken(Property.ofValue("test-token"))
+            .limit(Property.ofValue(10))
+            .fetchType(Property.ofValue(FetchType.FETCH))
             .build();
 
         assertThat(task.getStoreDomain(), notNullValue());

--- a/src/test/java/io/kestra/plugin/shopify/products/ListProductsTest.java
+++ b/src/test/java/io/kestra/plugin/shopify/products/ListProductsTest.java
@@ -32,9 +32,9 @@ class ListProductsTest {
         List task = List.builder()
             .id("test-task")
             .type(List.class.getName())
-            .storeDomain(Property.of(storeDomain))
-            .accessToken(Property.of(accessToken))
-            .limit(Property.of(5))
+            .storeDomain(Property.ofValue(storeDomain))
+            .accessToken(Property.ofValue(accessToken))
+            .limit(Property.ofValue(5))
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -58,7 +58,7 @@ class ListProductsTest {
             List task = List.builder()
                 .id("test-task")
                 .type(List.class.getName())
-                .accessToken(Property.of("test-token"))
+                .accessToken(Property.ofValue("test-token"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -70,7 +70,7 @@ class ListProductsTest {
             List task = List.builder()
                 .id("test-task")
                 .type(List.class.getName())
-                .storeDomain(Property.of("test-store.myshopify.com"))
+                .storeDomain(Property.ofValue("test-store.myshopify.com"))
                 .build();
 
             RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
@@ -84,10 +84,10 @@ class ListProductsTest {
         List task = List.builder()
             .id("test-task")
             .type(List.class.getName())
-            .storeDomain(Property.of("test-store.myshopify.com"))
-            .accessToken(Property.of("test-token"))
-            .limit(Property.of(10))
-            .fetchType(Property.of(FetchType.FETCH))
+            .storeDomain(Property.ofValue("test-store.myshopify.com"))
+            .accessToken(Property.ofValue("test-token"))
+            .limit(Property.ofValue(10))
+            .fetchType(Property.ofValue(FetchType.FETCH))
             .build();
 
         assertThat(task.getStoreDomain(), notNullValue());


### PR DESCRIPTION
## Summary
- Replace all deprecated `Property.of()` calls with `Property.ofValue()` (10 files, 64 occurrences)

## Test plan
- [ ] Verify compilation succeeds
- [ ] Run existing unit tests