### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/shopify/AbstractShopifyTask.java
+++ b/src/main/java/io/kestra/plugin/shopify/AbstractShopifyTask.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -32,6 +33,7 @@ public abstract class AbstractShopifyTask extends Task {
         description = "Store domain used for Admin API calls (e.g., my-store.myshopify.com)"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> storeDomain;
 
     @Schema(
@@ -39,6 +41,7 @@ public abstract class AbstractShopifyTask extends Task {
         description = "Private app Admin API access token sent as X-Shopify-Access-Token"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> accessToken;
 
     @Schema(
@@ -46,6 +49,7 @@ public abstract class AbstractShopifyTask extends Task {
         description = "Shopify Admin API version path segment; defaults to 2024-10"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<String> apiVersion = Property.ofValue("2024-10");
 
     @Schema(
@@ -53,6 +57,7 @@ public abstract class AbstractShopifyTask extends Task {
         description = "Sleep between API calls to respect Shopify rate limits; default 500ms"
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<Duration> rateLimitDelay = Property.ofValue(Duration.ofMillis(500));
 
     protected URI buildApiUrl(RunContext runContext, String path) throws Exception {

--- a/src/main/java/io/kestra/plugin/shopify/customers/Create.java
+++ b/src/main/java/io/kestra/plugin/shopify/customers/Create.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -58,24 +59,28 @@ public class Create extends AbstractShopifyTask implements RunnableTask<Create.O
         description = "Email address for the new customer (required)"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> email;
 
     @Schema(
         title = "First name",
         description = "Optional given name for the customer"
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> firstName;
 
     @Schema(
         title = "Last name",
         description = "Optional family name for the customer"
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> lastName;
 
     @Schema(
         title = "Phone number",
         description = "Optional phone number sent to Shopify"
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> phone;
 
     @Override

--- a/src/main/java/io/kestra/plugin/shopify/customers/Delete.java
+++ b/src/main/java/io/kestra/plugin/shopify/customers/Delete.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -53,6 +54,7 @@ public class Delete extends AbstractShopifyTask implements RunnableTask<VoidOutp
         description = "Shopify customer ID to delete"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Long> customerId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/shopify/customers/Get.java
+++ b/src/main/java/io/kestra/plugin/shopify/customers/Get.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -55,6 +56,7 @@ public class Get extends AbstractShopifyTask implements RunnableTask<Get.Output>
         description = "Shopify customer ID to retrieve"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Long> customerId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/shopify/customers/List.java
+++ b/src/main/java/io/kestra/plugin/shopify/customers/List.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -73,12 +74,14 @@ public class List extends AbstractShopifyTask implements RunnableTask<List.Outpu
     )
     @Builder.Default
     @NotNull
+    @PluginProperty(group = "processing")
     protected Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Schema(
         title = "Customer limit",
         description = "Maximum customers to return (1-250). Shopify caps at 250."
     )
+    @PluginProperty(group = "processing")
     protected Property<Integer> limit;
 
     @Override

--- a/src/main/java/io/kestra/plugin/shopify/orders/Delete.java
+++ b/src/main/java/io/kestra/plugin/shopify/orders/Delete.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -52,6 +53,7 @@ public class Delete extends AbstractShopifyTask implements RunnableTask<Delete.O
         description = "Shopify order ID to delete"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Long> orderId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/shopify/orders/List.java
+++ b/src/main/java/io/kestra/plugin/shopify/orders/List.java
@@ -20,6 +20,7 @@ import io.kestra.plugin.shopify.models.Order;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -88,60 +89,70 @@ public class List extends AbstractShopifyTask implements RunnableTask<List.Outpu
         description = "Controls result handling: FETCH (default), FETCH_ONE, or STORE"
     )
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Schema(
         title = "Limit",
         description = "Maximum number of orders to retrieve (1-250)"
     )
+    @PluginProperty(group = "processing")
     private Property<Integer> limit;
 
     @Schema(
         title = "Since ID",
         description = "Retrieve orders created after this Shopify order ID"
     )
+    @PluginProperty(group = "advanced")
     private Property<Long> sinceId;
 
     @Schema(
         title = "Status filter",
         description = "Order status filter: open, closed, cancelled, or any"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> status;
 
     @Schema(
         title = "Financial status filter",
         description = "Financial status filter (e.g., paid, pending, refunded)"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> financialStatus;
 
     @Schema(
         title = "Fulfillment status filter",
         description = "Fulfillment status filter (e.g., shipped, partial, unshipped)"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> fulfillmentStatus;
 
     @Schema(
         title = "Created at min",
         description = "Return orders created at or after this ISO-8601 timestamp"
     )
+    @PluginProperty(group = "destination")
     private Property<String> createdAtMin;
 
     @Schema(
         title = "Created at max",
         description = "Return orders created at or before this ISO-8601 timestamp"
     )
+    @PluginProperty(group = "destination")
     private Property<String> createdAtMax;
 
     @Schema(
         title = "Updated at min",
         description = "Return orders updated at or after this ISO-8601 timestamp"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> updatedAtMin;
 
     @Schema(
         title = "Updated at max",
         description = "Return orders updated at or before this ISO-8601 timestamp"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> updatedAtMax;
 
     @Override

--- a/src/main/java/io/kestra/plugin/shopify/products/List.java
+++ b/src/main/java/io/kestra/plugin/shopify/products/List.java
@@ -22,6 +22,7 @@ import io.kestra.plugin.shopify.models.PublishedStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -90,72 +91,84 @@ public class List extends AbstractShopifyTask implements RunnableTask<List.Outpu
         description = "Controls result handling: FETCH (default), FETCH_ONE, or STORE"
     )
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Schema(
         title = "Limit",
         description = "Maximum number of products to retrieve (1-250)"
     )
+    @PluginProperty(group = "processing")
     private Property<Integer> limit;
 
     @Schema(
         title = "Since ID",
         description = "Retrieve products created after this Shopify product ID"
     )
+    @PluginProperty(group = "advanced")
     private Property<Long> sinceId;
 
     @Schema(
         title = "Product status filter",
         description = "Product status filter: active, archived, or draft"
     )
+    @PluginProperty(group = "advanced")
     private Property<ProductStatus> status;
 
     @Schema(
         title = "Published status filter",
         description = "Published state filter: published, unpublished, or any"
     )
+    @PluginProperty(group = "destination")
     private Property<PublishedStatus> publishedStatus;
 
     @Schema(
         title = "Product type filter",
         description = "Filter products by product type string"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> productType;
 
     @Schema(
         title = "Vendor filter",
         description = "Filter products by vendor"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> vendor;
 
     @Schema(
         title = "Handle filter",
         description = "Filter products by product handle"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> handle;
 
     @Schema(
         title = "Created at min",
         description = "Return products created at or after this ISO-8601 timestamp"
     )
+    @PluginProperty(group = "destination")
     private Property<String> createdAtMin;
 
     @Schema(
         title = "Created at max",
         description = "Return products created at or before this ISO-8601 timestamp"
     )
+    @PluginProperty(group = "destination")
     private Property<String> createdAtMax;
 
     @Schema(
         title = "Updated at min",
         description = "Return products updated at or after this ISO-8601 timestamp"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> updatedAtMin;
 
     @Schema(
         title = "Updated at max",
         description = "Return products updated at or before this ISO-8601 timestamp"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> updatedAtMax;
 
     @Override

--- a/src/main/java/io/kestra/plugin/shopify/products/Update.java
+++ b/src/main/java/io/kestra/plugin/shopify/products/Update.java
@@ -18,6 +18,7 @@ import io.kestra.plugin.shopify.models.Product;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -56,72 +57,84 @@ public class Update extends AbstractShopifyTask implements RunnableTask<Update.O
         title = "Product ID",
         description = "Shopify product ID to update (required)"
     )
+    @PluginProperty(group = "advanced")
     private Property<Long> productId;
 
     @Schema(
         title = "Product title",
         description = "New product title"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> title;
 
     @Schema(
         title = "Product description HTML",
         description = "HTML body for the product description"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> bodyHtml;
 
     @Schema(
         title = "Vendor",
         description = "Vendor name"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> vendor;
 
     @Schema(
         title = "Product type",
         description = "Product type string"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> productType;
 
     @Schema(
         title = "Tags",
         description = "Comma-separated tags"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> tags;
 
     @Schema(
         title = "Status",
         description = "Product status: active, archived, or draft"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> status;
 
     @Schema(
         title = "Handle",
         description = "Unique URL handle for the product"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> handle;
 
     @Schema(
         title = "Template suffix",
         description = "Liquid template suffix used for the product page"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> templateSuffix;
 
     @Schema(
         title = "Published scope",
         description = "Publish scope (web or global)"
     )
+    @PluginProperty(group = "destination")
     private Property<String> publishedScope;
 
     @Schema(
         title = "SEO title",
         description = "SEO title to set in Shopify"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> seoTitle;
 
     @Schema(
         title = "SEO description",
         description = "SEO meta description"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> seoDescription;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712